### PR TITLE
Split each reconcile test into three

### DIFF
--- a/controllers/osccluster_subnet_controller_unit_test.go
+++ b/controllers/osccluster_subnet_controller_unit_test.go
@@ -307,8 +307,8 @@ func TestCheckSubnetFormatParameters(t *testing.T) {
 	}
 }
 
-// TestReconcileSubnet has several tests to cover the code of the function reconcileSubnet
-func TestReconcileSubnet(t *testing.T) {
+// TestReconcileSubnetCreate has several tests to cover the code of the function reconcileSubnet
+func TestReconcileSubnetCreate(t *testing.T) {
 	subnetTestCases := []struct {
 		name                  string
 		spec                  infrastructurev1beta1.OscClusterSpec
@@ -343,31 +343,6 @@ func TestReconcileSubnet(t *testing.T) {
 			expReconcileSubnetErr: nil,
 		},
 		{
-			name: "check Subnet exist (second time reconcile loop)",
-			spec: infrastructurev1beta1.OscClusterSpec{
-				Network: infrastructurev1beta1.OscNetwork{
-					Net: infrastructurev1beta1.OscNet{
-						Name:       "test-net",
-						IpRange:    "10.0.0.0/16",
-						ResourceId: "vpc-test-net-uid",
-					},
-					Subnets: []*infrastructurev1beta1.OscSubnet{
-						{
-							Name:          "test-subnet",
-							IpSubnetRange: "10.0.0.0/24",
-							ResourceId:    "subnet-test-subnet-uid",
-						},
-					},
-				},
-			},
-			expSubnetFound:        true,
-			expNetFound:           true,
-			expCreateSubnetFound:  false,
-			expCreateSubnetErr:    nil,
-			expGetSubnetIdsErr:    nil,
-			expReconcileSubnetErr: nil,
-		},
-		{
 			name: "create two Subnets (first time reconcile loop)",
 			spec: infrastructurev1beta1.OscClusterSpec{
 				Network: infrastructurev1beta1.OscNetwork{
@@ -390,36 +365,6 @@ func TestReconcileSubnet(t *testing.T) {
 			expSubnetFound:        false,
 			expNetFound:           true,
 			expCreateSubnetFound:  true,
-			expCreateSubnetErr:    nil,
-			expGetSubnetIdsErr:    nil,
-			expReconcileSubnetErr: nil,
-		},
-		{
-			name: "check two subnets exist (second time reconcile loop)",
-			spec: infrastructurev1beta1.OscClusterSpec{
-				Network: infrastructurev1beta1.OscNetwork{
-					Net: infrastructurev1beta1.OscNet{
-						Name:       "test-net",
-						IpRange:    "10.0.0.0/16",
-						ResourceId: "vpc-test-net-uid",
-					},
-					Subnets: []*infrastructurev1beta1.OscSubnet{
-						{
-							Name:          "test-subnet-first",
-							IpSubnetRange: "10.0.0.0/24",
-							ResourceId:    "subnet-test-subnet-first-uid",
-						},
-						{
-							Name:          "test-subnet-second",
-							IpSubnetRange: "10.0.1.0/24",
-							ResourceId:    "subnet-test-subnet-second-uid",
-						},
-					},
-				},
-			},
-			expSubnetFound:        true,
-			expNetFound:           true,
-			expCreateSubnetFound:  false,
 			expCreateSubnetErr:    nil,
 			expGetSubnetIdsErr:    nil,
 			expReconcileSubnetErr: nil,
@@ -448,31 +393,6 @@ func TestReconcileSubnet(t *testing.T) {
 			expReconcileSubnetErr: fmt.Errorf("CreateSubnet generic error Can not create subnet for Osccluster test-system/test-osc"),
 		},
 		{
-			name: "failed to get Subnet",
-			spec: infrastructurev1beta1.OscClusterSpec{
-				Network: infrastructurev1beta1.OscNetwork{
-					Net: infrastructurev1beta1.OscNet{
-						Name:       "test-net",
-						IpRange:    "10.0.0.0/16",
-						ResourceId: "vpc-test-net-uid",
-					},
-					Subnets: []*infrastructurev1beta1.OscSubnet{
-						{
-							Name:          "test-subnet",
-							IpSubnetRange: "10.0.0.0/24",
-							ResourceId:    "subnet-test-subnet-uid",
-						},
-					},
-				},
-			},
-			expSubnetFound:        false,
-			expNetFound:           true,
-			expCreateSubnetFound:  false,
-			expCreateSubnetErr:    nil,
-			expGetSubnetIdsErr:    fmt.Errorf("GetSubnet generic error"),
-			expReconcileSubnetErr: fmt.Errorf("GetSubnet generic error"),
-		},
-		{
 			name: "delete subnet without cluster-api",
 			spec: infrastructurev1beta1.OscClusterSpec{
 				Network: infrastructurev1beta1.OscNetwork{
@@ -496,31 +416,6 @@ func TestReconcileSubnet(t *testing.T) {
 			expCreateSubnetErr:    nil,
 			expGetSubnetIdsErr:    nil,
 			expReconcileSubnetErr: nil,
-		},
-		{
-			name: "Net does not exist",
-			spec: infrastructurev1beta1.OscClusterSpec{
-				Network: infrastructurev1beta1.OscNetwork{
-					Net: infrastructurev1beta1.OscNet{
-						Name:       "test-net",
-						IpRange:    "10.0.0.0/16",
-						ResourceId: "vpc-test-net",
-					},
-					Subnets: []*infrastructurev1beta1.OscSubnet{
-						{
-							Name:          "test-subnet",
-							IpSubnetRange: "10.0.0.0/24",
-							ResourceId:    "subnet-test-subnet-uid",
-						},
-					},
-				},
-			},
-			expSubnetFound:        false,
-			expNetFound:           false,
-			expCreateSubnetFound:  false,
-			expCreateSubnetErr:    nil,
-			expGetSubnetIdsErr:    nil,
-			expReconcileSubnetErr: fmt.Errorf("test-net-uid is not exist"),
 		},
 	}
 	for _, stc := range subnetTestCases {
@@ -568,15 +463,27 @@ func TestReconcileSubnet(t *testing.T) {
 				subnetRef.ResourceMap = make(map[string]string)
 				if stc.expCreateSubnetFound {
 					subnetRef.ResourceMap[subnetName] = subnetId
-					mockOscSubnetInterface.EXPECT().CreateSubnet(subnetSpec, netId, subnetName).Return(subnet.Subnet, stc.expCreateSubnetErr).AnyTimes()
+					mockOscSubnetInterface.
+						EXPECT().
+						CreateSubnet(gomock.Eq(subnetSpec), gomock.Eq(netId), gomock.Eq(subnetName)).
+						Return(subnet.Subnet, stc.expCreateSubnetErr)
 				} else {
-					mockOscSubnetInterface.EXPECT().CreateSubnet(subnetSpec, netId, subnetName).Return(nil, stc.expCreateSubnetErr).AnyTimes()
+					mockOscSubnetInterface.
+						EXPECT().
+						CreateSubnet(gomock.Eq(subnetSpec), gomock.Eq(netId), gomock.Eq(subnetName)).
+						Return(nil, stc.expCreateSubnetErr)
 				}
 			}
 			if stc.expSubnetFound {
-				mockOscSubnetInterface.EXPECT().GetSubnetIdsFromNetIds(netId).Return(subnetIds, stc.expGetSubnetIdsErr).AnyTimes()
+				mockOscSubnetInterface.
+					EXPECT().
+					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					Return(subnetIds, stc.expGetSubnetIdsErr)
 			} else {
-				mockOscSubnetInterface.EXPECT().GetSubnetIdsFromNetIds(netId).Return(nil, stc.expGetSubnetIdsErr).AnyTimes()
+				mockOscSubnetInterface.
+					EXPECT().
+					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					Return(nil, stc.expGetSubnetIdsErr)
 			}
 			netRef := clusterScope.GetNetRef()
 			netRef.ResourceMap = make(map[string]string)
@@ -594,8 +501,355 @@ func TestReconcileSubnet(t *testing.T) {
 	}
 }
 
-// TestReconcileDeleteSubnet has several tests to cover the code of the function reconcileDeleteSubnet
-func TestReconcileDeleteSubnet(t *testing.T) {
+// TestReconcileSubnetGet has several tests to cover the code of the function reconcileSubnet
+func TestReconcileSubnetGet(t *testing.T) {
+	subnetTestCases := []struct {
+		name                  string
+		spec                  infrastructurev1beta1.OscClusterSpec
+		expSubnetFound        bool
+		expNetFound           bool
+		expGetSubnetIdsErr    error
+		expReconcileSubnetErr error
+	}{
+		{
+			name: "check Subnet exist (second time reconcile loop)",
+			spec: infrastructurev1beta1.OscClusterSpec{
+				Network: infrastructurev1beta1.OscNetwork{
+					Net: infrastructurev1beta1.OscNet{
+						Name:       "test-net",
+						IpRange:    "10.0.0.0/16",
+						ResourceId: "vpc-test-net-uid",
+					},
+					Subnets: []*infrastructurev1beta1.OscSubnet{
+						{
+							Name:          "test-subnet",
+							IpSubnetRange: "10.0.0.0/24",
+							ResourceId:    "subnet-test-subnet-uid",
+						},
+					},
+				},
+			},
+			expSubnetFound:        true,
+			expNetFound:           true,
+			expGetSubnetIdsErr:    nil,
+			expReconcileSubnetErr: nil,
+		},
+		{
+			name: "check two subnets exist (second time reconcile loop)",
+			spec: infrastructurev1beta1.OscClusterSpec{
+				Network: infrastructurev1beta1.OscNetwork{
+					Net: infrastructurev1beta1.OscNet{
+						Name:       "test-net",
+						IpRange:    "10.0.0.0/16",
+						ResourceId: "vpc-test-net-uid",
+					},
+					Subnets: []*infrastructurev1beta1.OscSubnet{
+						{
+							Name:          "test-subnet-first",
+							IpSubnetRange: "10.0.0.0/24",
+							ResourceId:    "subnet-test-subnet-first-uid",
+						},
+						{
+							Name:          "test-subnet-second",
+							IpSubnetRange: "10.0.1.0/24",
+							ResourceId:    "subnet-test-subnet-second-uid",
+						},
+					},
+				},
+			},
+			expSubnetFound:        true,
+			expNetFound:           true,
+			expGetSubnetIdsErr:    nil,
+			expReconcileSubnetErr: nil,
+		},
+		{
+			name: "failed to get Subnet",
+			spec: infrastructurev1beta1.OscClusterSpec{
+				Network: infrastructurev1beta1.OscNetwork{
+					Net: infrastructurev1beta1.OscNet{
+						Name:       "test-net",
+						IpRange:    "10.0.0.0/16",
+						ResourceId: "vpc-test-net-uid",
+					},
+					Subnets: []*infrastructurev1beta1.OscSubnet{
+						{
+							Name:          "test-subnet",
+							IpSubnetRange: "10.0.0.0/24",
+							ResourceId:    "subnet-test-subnet-uid",
+						},
+					},
+				},
+			},
+			expSubnetFound:        false,
+			expNetFound:           true,
+			expGetSubnetIdsErr:    fmt.Errorf("GetSubnet generic error"),
+			expReconcileSubnetErr: fmt.Errorf("GetSubnet generic error"),
+		},
+	}
+	for _, stc := range subnetTestCases {
+		t.Run(stc.name, func(t *testing.T) {
+			t.Logf("Validate to %s", stc.name)
+			mockCtrl := gomock.NewController(t)
+			mockOscSubnetInterface := mock_net.NewMockOscSubnetInterface(mockCtrl)
+			netName := stc.spec.Network.Net.Name + "-uid"
+			netId := "vpc-" + netName
+			subnetsSpec := stc.spec.Network.Subnets
+			ctx := context.Background()
+			var subnetIds []string
+			var clusterScope *scope.ClusterScope
+			for _, subnetSpec := range subnetsSpec {
+				subnetName := subnetSpec.Name + "-uid"
+				subnetId := "subnet-" + subnetName
+				subnetIds = append(subnetIds, subnetId)
+				oscCluster := infrastructurev1beta1.OscCluster{
+					Spec: stc.spec,
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "uid",
+						Name:      "test-osc",
+						Namespace: "test-system",
+					},
+				}
+				log := klogr.New()
+				clusterScope = &scope.ClusterScope{
+					Logger: log,
+					Cluster: &clusterv1.Cluster{
+						ObjectMeta: metav1.ObjectMeta{
+							UID:       "uid",
+							Name:      "test-osc",
+							Namespace: "test-system",
+						},
+					},
+					OscCluster: &oscCluster,
+				}
+
+			}
+			if stc.expSubnetFound {
+				mockOscSubnetInterface.
+					EXPECT().
+					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					Return(subnetIds, stc.expGetSubnetIdsErr)
+			} else {
+				mockOscSubnetInterface.
+					EXPECT().
+					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					Return(nil, stc.expGetSubnetIdsErr)
+			}
+			netRef := clusterScope.GetNetRef()
+			netRef.ResourceMap = make(map[string]string)
+			if stc.expNetFound {
+				netRef.ResourceMap[netName] = netId
+			}
+			reconcileSubnet, err := reconcileSubnet(ctx, clusterScope, mockOscSubnetInterface)
+			if err != nil {
+				if err.Error() != stc.expReconcileSubnetErr.Error() {
+					t.Errorf("reconcileSubnet() expected error = %s, received error %s", stc.expReconcileSubnetErr, err.Error())
+				}
+			}
+			t.Logf("Find reconcileSubnet  %v\n", reconcileSubnet)
+		})
+	}
+}
+
+// TestReconcileSubnetResourceId has several tests to cover the code of the function reconcileSubnet
+func TestReconcileSubnetResourceId(t *testing.T) {
+	subnetTestCases := []struct {
+		name                  string
+		spec                  infrastructurev1beta1.OscClusterSpec
+		expSubnetFound        bool
+		expNetFound           bool
+		expReconcileSubnetErr error
+	}{
+		{
+			name: "Net does not exist",
+			spec: infrastructurev1beta1.OscClusterSpec{
+				Network: infrastructurev1beta1.OscNetwork{
+					Net: infrastructurev1beta1.OscNet{
+						Name:       "test-net",
+						IpRange:    "10.0.0.0/16",
+						ResourceId: "vpc-test-net",
+					},
+					Subnets: []*infrastructurev1beta1.OscSubnet{
+						{
+							Name:          "test-subnet",
+							IpSubnetRange: "10.0.0.0/24",
+							ResourceId:    "subnet-test-subnet-uid",
+						},
+					},
+				},
+			},
+			expSubnetFound:        false,
+			expNetFound:           false,
+			expReconcileSubnetErr: fmt.Errorf("test-net-uid is not exist"),
+		},
+	}
+	for _, stc := range subnetTestCases {
+		t.Run(stc.name, func(t *testing.T) {
+			t.Logf("Validate to %s", stc.name)
+			mockCtrl := gomock.NewController(t)
+			mockOscSubnetInterface := mock_net.NewMockOscSubnetInterface(mockCtrl)
+			netName := stc.spec.Network.Net.Name + "-uid"
+			netId := "vpc-" + netName
+			ctx := context.Background()
+			var clusterScope *scope.ClusterScope
+			oscCluster := infrastructurev1beta1.OscCluster{
+				Spec: stc.spec,
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "uid",
+					Name:      "test-osc",
+					Namespace: "test-system",
+				},
+			}
+			log := klogr.New()
+			clusterScope = &scope.ClusterScope{
+				Logger: log,
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "uid",
+						Name:      "test-osc",
+						Namespace: "test-system",
+					},
+				},
+				OscCluster: &oscCluster,
+			}
+
+			netRef := clusterScope.GetNetRef()
+			netRef.ResourceMap = make(map[string]string)
+			if stc.expNetFound {
+				netRef.ResourceMap[netName] = netId
+			}
+			reconcileSubnet, err := reconcileSubnet(ctx, clusterScope, mockOscSubnetInterface)
+			if err != nil {
+				if err.Error() != stc.expReconcileSubnetErr.Error() {
+					t.Errorf("reconcileSubnet() expected error = %s, received error %s", stc.expReconcileSubnetErr, err.Error())
+				}
+			}
+			t.Logf("Find reconcileSubnet  %v\n", reconcileSubnet)
+		})
+	}
+}
+
+// TestReconcileDeleteSubnetGet has several tests to cover the code of the function reconcileDeleteSubnet
+func TestReconcileDeleteSubnetGet(t *testing.T) {
+	subnetTestCases := []struct {
+		name                        string
+		spec                        infrastructurev1beta1.OscClusterSpec
+		expSubnetFound              bool
+		expNetFound                 bool
+		expGetSubnetIdsErr          error
+		expReconcileDeleteSubnetErr error
+	}{
+		{
+			name: "Failed to get subnet",
+			spec: infrastructurev1beta1.OscClusterSpec{
+				Network: infrastructurev1beta1.OscNetwork{
+					Net: infrastructurev1beta1.OscNet{
+						Name:       "test-net",
+						IpRange:    "10.0.0.0/16",
+						ResourceId: "vpc-test-net-uid",
+					},
+					Subnets: []*infrastructurev1beta1.OscSubnet{
+						{
+							Name:          "test-subnet",
+							IpSubnetRange: "10.0.0.0/24",
+							ResourceId:    "subnet-test-subnet-uid",
+						},
+					},
+				},
+			},
+			expSubnetFound:              false,
+			expNetFound:                 true,
+			expGetSubnetIdsErr:          fmt.Errorf("GetSubnet generic error"),
+			expReconcileDeleteSubnetErr: fmt.Errorf("GetSubnet generic error"),
+		},
+		{
+			name: "Remove finalizer (delete Subnets without cluster-api)",
+			spec: infrastructurev1beta1.OscClusterSpec{
+				Network: infrastructurev1beta1.OscNetwork{
+					Net: infrastructurev1beta1.OscNet{
+						Name:       "test-net",
+						IpRange:    "10.0.0.0/16",
+						ResourceId: "vpc-test-net-uid",
+					},
+					Subnets: []*infrastructurev1beta1.OscSubnet{
+						{
+							Name:          "test-subnet",
+							IpSubnetRange: "10.0.0.0/24",
+							ResourceId:    "subnet-test-subnet-uid",
+						},
+					},
+				},
+			},
+			expSubnetFound:              false,
+			expNetFound:                 true,
+			expGetSubnetIdsErr:          nil,
+			expReconcileDeleteSubnetErr: nil,
+		},
+	}
+	for _, stc := range subnetTestCases {
+		t.Run(stc.name, func(t *testing.T) {
+			t.Logf("Validate to %s", stc.name)
+			mockCtrl := gomock.NewController(t)
+			mockOscSubnetInterface := mock_net.NewMockOscSubnetInterface(mockCtrl)
+			netName := stc.spec.Network.Net.Name + "-uid"
+			netId := "vpc-" + netName
+			subnetsSpec := stc.spec.Network.Subnets
+			var subnetIds []string
+			ctx := context.Background()
+			for _, subnetSpec := range subnetsSpec {
+				subnetName := subnetSpec.Name + "-uid"
+				subnetId := "subnet-" + subnetName
+				subnetIds = append(subnetIds, subnetId)
+			}
+			if stc.expSubnetFound {
+				mockOscSubnetInterface.
+					EXPECT().
+					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					Return(subnetIds, stc.expGetSubnetIdsErr)
+			} else {
+				mockOscSubnetInterface.
+					EXPECT().
+					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					Return(nil, stc.expGetSubnetIdsErr)
+			}
+			oscCluster := infrastructurev1beta1.OscCluster{
+				Spec: stc.spec,
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "uid",
+					Name:      "test-osc",
+					Namespace: "test-system",
+				},
+			}
+			log := klogr.New()
+			clusterScope := &scope.ClusterScope{
+				Logger: log,
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "uid",
+						Name:      "test-osc",
+						Namespace: "test-system",
+					},
+				},
+				OscCluster: &oscCluster,
+			}
+
+			netRef := clusterScope.GetNetRef()
+			netRef.ResourceMap = make(map[string]string)
+			if stc.expNetFound {
+				netRef.ResourceMap[netName] = netId
+			}
+			reconcileDeleteSubnet, err := reconcileDeleteSubnet(ctx, clusterScope, mockOscSubnetInterface)
+			if err != nil {
+				if err.Error() != stc.expReconcileDeleteSubnetErr.Error() {
+					t.Errorf("reconcileDeleteSubnet() expected error %s, received error %s", stc.expReconcileDeleteSubnetErr, err.Error())
+				}
+			}
+			t.Logf("Find reconcileDeleteSubnet %v\n", reconcileDeleteSubnet)
+		})
+	}
+}
+
+// TestReconcileDeleteSubnetDelete has several tests to cover the code of the function reconcileDeleteSubnet
+func TestReconcileDeleteSubnetDelete(t *testing.T) {
 	subnetTestCases := []struct {
 		name                        string
 		spec                        infrastructurev1beta1.OscClusterSpec
@@ -659,30 +913,6 @@ func TestReconcileDeleteSubnet(t *testing.T) {
 			expReconcileDeleteSubnetErr: nil,
 		},
 		{
-			name: "Failed to get subnet",
-			spec: infrastructurev1beta1.OscClusterSpec{
-				Network: infrastructurev1beta1.OscNetwork{
-					Net: infrastructurev1beta1.OscNet{
-						Name:       "test-net",
-						IpRange:    "10.0.0.0/16",
-						ResourceId: "vpc-test-net-uid",
-					},
-					Subnets: []*infrastructurev1beta1.OscSubnet{
-						{
-							Name:          "test-subnet",
-							IpSubnetRange: "10.0.0.0/24",
-							ResourceId:    "subnet-test-subnet-uid",
-						},
-					},
-				},
-			},
-			expSubnetFound:              false,
-			expNetFound:                 true,
-			expDeleteSubnetErr:          nil,
-			expGetSubnetIdsErr:          fmt.Errorf("GetSubnet generic error"),
-			expReconcileDeleteSubnetErr: fmt.Errorf("GetSubnet generic error"),
-		},
-		{
 			name: "failed to delete Subnet",
 			spec: infrastructurev1beta1.OscClusterSpec{
 				Network: infrastructurev1beta1.OscNetwork{
@@ -706,6 +936,83 @@ func TestReconcileDeleteSubnet(t *testing.T) {
 			expGetSubnetIdsErr:          nil,
 			expReconcileDeleteSubnetErr: fmt.Errorf("DeleteSubnet generic error Can not delete subnet for Osccluster test-system/test-osc"),
 		},
+	}
+	for _, stc := range subnetTestCases {
+		t.Run(stc.name, func(t *testing.T) {
+			t.Logf("Validate to %s", stc.name)
+			mockCtrl := gomock.NewController(t)
+			mockOscSubnetInterface := mock_net.NewMockOscSubnetInterface(mockCtrl)
+			netName := stc.spec.Network.Net.Name + "-uid"
+			netId := "vpc-" + netName
+			subnetsSpec := stc.spec.Network.Subnets
+			var subnetIds []string
+			ctx := context.Background()
+			for _, subnetSpec := range subnetsSpec {
+				subnetName := subnetSpec.Name + "-uid"
+				subnetId := "subnet-" + subnetName
+				subnetIds = append(subnetIds, subnetId)
+				mockOscSubnetInterface.
+					EXPECT().
+					DeleteSubnet(gomock.Eq(subnetId)).
+					Return(stc.expDeleteSubnetErr)
+			}
+			if stc.expSubnetFound {
+				mockOscSubnetInterface.
+					EXPECT().
+					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					Return(subnetIds, stc.expGetSubnetIdsErr)
+			} else {
+				mockOscSubnetInterface.
+					EXPECT().
+					GetSubnetIdsFromNetIds(gomock.Eq(netId)).
+					Return(nil, stc.expGetSubnetIdsErr)
+			}
+			oscCluster := infrastructurev1beta1.OscCluster{
+				Spec: stc.spec,
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "uid",
+					Name:      "test-osc",
+					Namespace: "test-system",
+				},
+			}
+			log := klogr.New()
+			clusterScope := &scope.ClusterScope{
+				Logger: log,
+				Cluster: &clusterv1.Cluster{
+					ObjectMeta: metav1.ObjectMeta{
+						UID:       "uid",
+						Name:      "test-osc",
+						Namespace: "test-system",
+					},
+				},
+				OscCluster: &oscCluster,
+			}
+
+			netRef := clusterScope.GetNetRef()
+			netRef.ResourceMap = make(map[string]string)
+			if stc.expNetFound {
+				netRef.ResourceMap[netName] = netId
+			}
+			reconcileDeleteSubnet, err := reconcileDeleteSubnet(ctx, clusterScope, mockOscSubnetInterface)
+			if err != nil {
+				if err.Error() != stc.expReconcileDeleteSubnetErr.Error() {
+					t.Errorf("reconcileDeleteSubnet() expected error %s, received error %s", stc.expReconcileDeleteSubnetErr, err.Error())
+				}
+			}
+			t.Logf("Find reconcileDeleteSubnet %v\n", reconcileDeleteSubnet)
+		})
+	}
+}
+
+// TestReconcileDeleteSubnetResourceId has several tests to cover the code of the function reconcileDeleteSubnet
+func TestReconcileDeleteSubnetResourceId(t *testing.T) {
+	subnetTestCases := []struct {
+		name                        string
+		spec                        infrastructurev1beta1.OscClusterSpec
+		expSubnetFound              bool
+		expNetFound                 bool
+		expReconcileDeleteSubnetErr error
+	}{
 		{
 			name: "Net does not exist",
 			spec: infrastructurev1beta1.OscClusterSpec{
@@ -726,33 +1033,7 @@ func TestReconcileDeleteSubnet(t *testing.T) {
 			},
 			expSubnetFound:              false,
 			expNetFound:                 false,
-			expDeleteSubnetErr:          nil,
-			expGetSubnetIdsErr:          nil,
 			expReconcileDeleteSubnetErr: fmt.Errorf("test-net-uid is not exist"),
-		},
-		{
-			name: "Remove finalizer (delete Subnets without cluster-api)",
-			spec: infrastructurev1beta1.OscClusterSpec{
-				Network: infrastructurev1beta1.OscNetwork{
-					Net: infrastructurev1beta1.OscNet{
-						Name:       "test-net",
-						IpRange:    "10.0.0.0/16",
-						ResourceId: "vpc-test-net-uid",
-					},
-					Subnets: []*infrastructurev1beta1.OscSubnet{
-						{
-							Name:          "test-subnet",
-							IpSubnetRange: "10.0.0.0/24",
-							ResourceId:    "subnet-test-subnet-uid",
-						},
-					},
-				},
-			},
-			expSubnetFound:              false,
-			expNetFound:                 true,
-			expDeleteSubnetErr:          nil,
-			expGetSubnetIdsErr:          nil,
-			expReconcileDeleteSubnetErr: nil,
 		},
 	}
 	for _, stc := range subnetTestCases {
@@ -762,20 +1043,7 @@ func TestReconcileDeleteSubnet(t *testing.T) {
 			mockOscSubnetInterface := mock_net.NewMockOscSubnetInterface(mockCtrl)
 			netName := stc.spec.Network.Net.Name + "-uid"
 			netId := "vpc-" + netName
-			subnetsSpec := stc.spec.Network.Subnets
-			var subnetIds []string
 			ctx := context.Background()
-			for _, subnetSpec := range subnetsSpec {
-				subnetName := subnetSpec.Name + "-uid"
-				subnetId := "subnet-" + subnetName
-				subnetIds = append(subnetIds, subnetId)
-				mockOscSubnetInterface.EXPECT().DeleteSubnet(subnetId).Return(stc.expDeleteSubnetErr).AnyTimes()
-			}
-			if stc.expSubnetFound {
-				mockOscSubnetInterface.EXPECT().GetSubnetIdsFromNetIds(netId).Return(subnetIds, stc.expGetSubnetIdsErr).AnyTimes()
-			} else {
-				mockOscSubnetInterface.EXPECT().GetSubnetIdsFromNetIds(netId).Return(nil, stc.expGetSubnetIdsErr).AnyTimes()
-			}
 			oscCluster := infrastructurev1beta1.OscCluster{
 				Spec: stc.spec,
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
* Each test will or not use only mock that it needs.

* GetRessourceId failure will not use mock.
* Use gomock.Eq

* Change also format.