### PR TITLE
Upgrade Github CI to use default OMI_ID

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -50,6 +50,7 @@ jobs:
         worker_volume_type: "io1"
         worker_volume_size: 30
         worker_iops: 1500
+        image_id: ${{ secrets.OMI_ID }}
     - name: Wait Kubernetes control plane is up and running
       uses: nick-invision/retry@v2
       with:

--- a/.github/workflows/kind.yaml
+++ b/.github/workflows/kind.yaml
@@ -60,6 +60,7 @@ jobs:
         worker_volume_type: "io1"
         worker_volume_size: 30
         worker_iops: 1500
+        image_id: ${{ secrets.OMI_ID }}
     - name: Wait Kubernetes control plane is up and running
       uses: nick-invision/retry@v2
       with:

--- a/.github/workflows/unit-func-e2e-test.yaml
+++ b/.github/workflows/unit-func-e2e-test.yaml
@@ -87,6 +87,7 @@ jobs:
         worker_volume_type: "io1"
         worker_volume_size: 30
         worker_iops: 1500
+        image_id: ${{ secrets.OMI_ID }}
     - name: Wait Kubernetes control plane is up and running
       uses: nick-invision/retry@v2
       with:
@@ -242,6 +243,7 @@ jobs:
         worker_volume_type: "io1"
         worker_volume_size: 30
         worker_iops: 1500
+        image_id: ${{ secrets.OMI_ID }}
     - name: Wait Kubernetes control plane is up and running
       uses: nick-invision/retry@v2
       with:


### PR DESCRIPTION
When the cloud account will be migrating, the ID of the OMI will change, theses changes will make that transparent

Canceling Ci because it will not take into account these changes