### PR TITLE
[WIP] Make LoadBalancer optionnal to OscCluster

### DIFF
--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -133,6 +133,7 @@ type OscLoadBalancer struct {
 	HealthCheck OscLoadBalancerHealthCheck `json:"healthCheck,omitempty"`
 	// unused
 	ClusterName string `json:"clusterName,omitempty"`
+	Enable      bool   `json:"enable,omitempty"`
 }
 
 type OscLoadBalancerListener struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclusters.yaml
@@ -245,6 +245,8 @@ spec:
                       clusterName:
                         description: unused
                         type: string
+                      enable:
+                        type: boolean
                       healthCheck:
                         description: The healthCheck configuration of the Load Balancer
                         properties:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_oscclustertemplates.yaml
@@ -295,6 +295,8 @@ spec:
                               clusterName:
                                 description: unused
                                 type: string
+                              enable:
+                                type: boolean
                               healthCheck:
                                 description: The healthCheck configuration of the
                                   Load Balancer


### PR DESCRIPTION
**What type of PR is this?**

Feature request #558 

/kind feature

**What this PR does / why we need it**:

To support HostedControlPlane solution like Kamaji, the infrastrucuter provider should allow to not deploy any loadbalancer for the control plane (in the case the control plane is already deployed and managed by another controlplane provider.

This commit add an extra field Enable on the loadbalancer spec, like the Bastion spec, to skip its reconciliation

**Which issue(s) this PR fixes**:

Fixes #558

**Special notes for your reviewer**:

After we cover this topic, I will make subsequent pull request on the Kamaji control plane provider side to add first class support of Outscale infrastructure provider

**TODOs**:

- [X] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
