### PR TITLE
✨ feat(OscCluster): disable load-balancer

### DIFF
--- a/.github/workflows/unit-quickstart-e2e-test.yaml
+++ b/.github/workflows/unit-quickstart-e2e-test.yaml
@@ -7,13 +7,14 @@ on:
   pull_request:
     branches: [ main ]
     paths:
-      - ".github/workflows/unit-func-e2e-test.yaml"
+      - ".github/workflows/unit-quickstart-e2e-test.yaml"
       - "github_actions/deploy_cluster/**"
       - "**.go"
       - "**.yaml"
       - "!capm.yaml"
       - "!osc-secret.yaml"
       - "!example/**.yaml"
+      - "!.github/**.yaml"
       - "!testclean/**"
       - "!helm/**"
       - "Makefile"

--- a/api/v1beta1/types.go
+++ b/api/v1beta1/types.go
@@ -123,11 +123,12 @@ type OscReuse struct {
 	SecurityGroups bool `json:"securityGroups,omitempty"`
 }
 
-// +kubebuilder:validation:Enum:=internet
+// +kubebuilder:validation:Enum:=internet;loadbalancer
 type OscDisable string
 
 const (
 	DisableInternet OscDisable = "internet"
+	DisableLB       OscDisable = "loadbalancer"
 )
 
 type OscLoadBalancer struct {

--- a/cloud/scope/cluster.go
+++ b/cloud/scope/cluster.go
@@ -233,6 +233,11 @@ func (s *ClusterScope) IsInternetDisabled() bool {
 	return slices.Contains(s.GetNetwork().Disable, infrastructurev1beta1.DisableInternet)
 }
 
+// IsLBDisabled checks if loadbalancer is disabled.
+func (s *ClusterScope) IsLBDisabled() bool {
+	return slices.Contains(s.GetNetwork().Disable, infrastructurev1beta1.DisableLB)
+}
+
 // GetInternetServiceName return the name of the net
 func (s *ClusterScope) GetInternetServiceName() string {
 	if s.OscCluster.Spec.Network.InternetService.Name != "" {

--- a/controllers/osccluster_controller_test.go
+++ b/controllers/osccluster_controller_test.go
@@ -229,7 +229,7 @@ func TestReconcileOSCCluster_Create(t *testing.T) {
 						"test-cluster-api-natservice-9e1db9c4-bf0a-4583-8999-203ec002c520": "ipalloc-nat",
 					},
 				}),
-				assertControlPlaneEndpoint("test-cluster-api-k8s.outscale.dev"),
+				assertControlPlaneEndpoint("test-cluster-api-k8s.outscale.dev", 6443),
 			},
 			next: &testcase{
 				name: "A second run has all references in cache",
@@ -360,7 +360,7 @@ func TestReconcileOSCCluster_Create(t *testing.T) {
 						"eu-west-2a-9e1db9c4-bf0a-4583-8999-203ec002c520": "ipalloc-nat",
 					},
 				}),
-				assertControlPlaneEndpoint("test-cluster-api-k8s.outscale.dev"),
+				assertControlPlaneEndpoint("test-cluster-api-k8s.outscale.dev", 6443),
 			},
 			next: &testcase{
 				name: "A second run has all references in cache",
@@ -1102,7 +1102,7 @@ func TestReconcileOSCCluster_Create(t *testing.T) {
 						"test-cluster-api-node-9e1db9c4-bf0a-4583-8999-203ec002c520":         "sg-node",
 					},
 				}),
-				assertControlPlaneEndpoint("test-cluster-api-k8s.outscale.dev"),
+				assertControlPlaneEndpoint("test-cluster-api-k8s.outscale.dev", 6443),
 			},
 		},
 		{
@@ -1143,7 +1143,7 @@ func TestReconcileOSCCluster_Create(t *testing.T) {
 			clusterAsserts: []assertOSCClusterFunc{
 				assertHasClusterFinalizer(),
 				assertStatusClusterResources(infrastructurev1beta1.OscClusterResources{}),
-				assertControlPlaneEndpoint("test-cluster-api-k8s.outscale.dev"),
+				assertControlPlaneEndpoint("test-cluster-api-k8s.outscale.dev", 6443),
 			},
 		},
 		{
@@ -1272,7 +1272,134 @@ func TestReconcileOSCCluster_Create(t *testing.T) {
 						"eu-west-2a-9e1db9c4-bf0a-4583-8999-203ec002c520": "ipalloc-nat",
 					},
 				}),
-				assertControlPlaneEndpoint("test-cluster-api-k8s.outscale.dev"),
+				assertControlPlaneEndpoint("test-cluster-api-k8s.outscale.dev", 6443),
+			},
+			next: &testcase{
+				name: "A second run has all references in cache",
+			},
+		},
+		{
+			name:           "disabling LBU",
+			clusterSpec:    "base-1.0",
+			clusterPatches: []patchOSCClusterFunc{patchDisableLB()},
+			mockFuncs: []mockFunc{
+				mockReadOwnedByTag(tag.NetResourceType, "9e1db9c4-bf0a-4583-8999-203ec002c520", nil),
+				mockCreateNet(infrastructurev1beta1.OscNet{
+					IpRange: "10.0.0.0/16",
+				}, "9e1db9c4-bf0a-4583-8999-203ec002c520", "Net for test-cluster-api", "vpc-foo"),
+				mockGetSubnetFromNet("vpc-foo", "10.0.4.0/24", nil),
+				mockCreateSubnet(infrastructurev1beta1.OscSubnet{
+					IpSubnetRange: "10.0.4.0/24",
+					SubregionName: "eu-west-2a",
+					Roles:         []infrastructurev1beta1.OscRole{infrastructurev1beta1.RoleControlPlane},
+				}, "vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "Controlplane subnet for test-cluster-api/eu-west-2a", "subnet-kcp"),
+				mockGetSubnetFromNet("vpc-foo", "10.0.3.0/24", nil),
+				mockCreateSubnet(infrastructurev1beta1.OscSubnet{
+					IpSubnetRange: "10.0.3.0/24",
+					SubregionName: "eu-west-2a",
+					Roles:         []infrastructurev1beta1.OscRole{infrastructurev1beta1.RoleWorker},
+				}, "vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "Worker subnet for test-cluster-api/eu-west-2a", "subnet-kw"),
+				mockGetSubnetFromNet("vpc-foo", "10.0.2.0/24", nil),
+				mockCreateSubnet(infrastructurev1beta1.OscSubnet{
+					IpSubnetRange: "10.0.2.0/24",
+					SubregionName: "eu-west-2a",
+					Roles:         []infrastructurev1beta1.OscRole{infrastructurev1beta1.RoleLoadBalancer, infrastructurev1beta1.RoleBastion, infrastructurev1beta1.RoleNat},
+				}, "vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "Public subnet for test-cluster-api/eu-west-2a", "subnet-public"),
+				mockGetInternetServiceForNet("vpc-foo", nil),
+				mockCreateInternetService("Internet Service for test-cluster-api", "9e1db9c4-bf0a-4583-8999-203ec002c520", "igw-foo"),
+				mockLinkInternetService("igw-foo", "vpc-foo"),
+
+				mockGetSecurityGroupFromName("test-cluster-api-worker-9e1db9c4-bf0a-4583-8999-203ec002c520", nil),
+				mockCreateSecurityGroup("vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "test-cluster-api-worker-9e1db9c4-bf0a-4583-8999-203ec002c520",
+					"Worker securityGroup for test-cluster-api", "", []infrastructurev1beta1.OscRole{infrastructurev1beta1.RoleWorker}, "sg-kw"),
+				mockCreateSecurityGroupRule("sg-kw", "Inbound", "tcp", "10.0.3.0/24", 10250, 10250),
+				mockCreateSecurityGroupRule("sg-kw", "Inbound", "tcp", "10.0.4.0/24", 10250, 10250),
+				mockCreateSecurityGroupRule("sg-kw", "Inbound", "tcp", "10.0.4.0/24", 443, 443),
+				mockCreateSecurityGroupRule("sg-kw", "Inbound", "tcp", "10.0.4.0/24", 1024, 65535),
+
+				mockGetSecurityGroupFromName("test-cluster-api-controlplane-9e1db9c4-bf0a-4583-8999-203ec002c520", nil),
+				mockCreateSecurityGroup("vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "test-cluster-api-controlplane-9e1db9c4-bf0a-4583-8999-203ec002c520",
+					"Controlplane securityGroup for test-cluster-api", "", []infrastructurev1beta1.OscRole{infrastructurev1beta1.RoleControlPlane}, "sg-kcp"),
+				mockCreateSecurityGroupRule("sg-kcp", "Inbound", "tcp", "10.0.4.0/24", 10250, 10252),
+				mockCreateSecurityGroupRule("sg-kcp", "Inbound", "tcp", "10.0.0.0/16", 6443, 6443),
+				mockCreateSecurityGroupRule("sg-kcp", "Inbound", "tcp", "10.0.4.0/24", 2378, 2380),
+
+				mockGetSecurityGroupFromName("test-cluster-api-lb-9e1db9c4-bf0a-4583-8999-203ec002c520", nil),
+				mockCreateSecurityGroup("vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "test-cluster-api-lb-9e1db9c4-bf0a-4583-8999-203ec002c520",
+					"LB securityGroup for test-cluster-api", "", []infrastructurev1beta1.OscRole{infrastructurev1beta1.RoleLoadBalancer}, "sg-lb"),
+				mockCreateSecurityGroupRule("sg-lb", "Inbound", "tcp", "0.0.0.0/0", 6443, 6443),
+				mockCreateSecurityGroupRule("sg-lb", "Outbound", "tcp", "10.0.4.0/24", 6443, 6443),
+
+				mockGetSecurityGroupFromName("test-cluster-api-node-9e1db9c4-bf0a-4583-8999-203ec002c520", nil),
+				mockCreateSecurityGroup("vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "test-cluster-api-node-9e1db9c4-bf0a-4583-8999-203ec002c520",
+					"Node securityGroup for test-cluster-api", "OscK8sMainSG", []infrastructurev1beta1.OscRole{infrastructurev1beta1.RoleControlPlane, infrastructurev1beta1.RoleWorker}, "sg-node"),
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "tcp", "10.0.0.0/16", 179, 179),
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "udp", "10.0.0.0/16", 4789, 4789),
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "udp", "10.0.0.0/16", 5473, 5473),
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "udp", "10.0.0.0/16", 8285, 8285),
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "udp", "10.0.0.0/16", 51820, 51821),
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "4", "10.0.0.0/16", -1, -1),
+
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "icmp", "10.0.0.0/16", 8, 8),
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "tcp", "10.0.0.0/16", 4240, 4240),
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "tcp", "10.0.0.0/16", 4244, 4244),
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "udp", "10.0.0.0/16", 8472, 8472),
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "udp", "10.0.0.0/16", 51871, 51871),
+
+				mockCreateSecurityGroupRule("sg-node", "Inbound", "tcp", "10.0.0.0/16", 30000, 32767),
+				mockCreateSecurityGroupRule("sg-node", "Outbound", "-1", "0.0.0.0/0", -1, -1),
+				mockCreateSecurityGroupRule("sg-node", "Outbound", "-1", "10.0.0.0/16", -1, -1),
+
+				mockGetRouteTablesFromNet("vpc-foo", nil),
+				mockCreateRouteTable("vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "Public subnet for test-cluster-api/eu-west-2a", "rtb-public"),
+				mockLinkRouteTable("rtb-public", "subnet-public"),
+				mockCreateRoute("rtb-public", "0.0.0.0/0", "igw-foo", "gateway"),
+
+				mockGetNatServiceFromClientToken("eu-west-2a-9e1db9c4-bf0a-4583-8999-203ec002c520", nil),
+				mockCreatePublicIp("Nat service for test-cluster-api/eu-west-2a", "9e1db9c4-bf0a-4583-8999-203ec002c520", "ipalloc-nat-2a", "1.2.3.4"),
+				mockCreateNatService("ipalloc-nat-2a", "subnet-public", "eu-west-2a-9e1db9c4-bf0a-4583-8999-203ec002c520", "Nat service for test-cluster-api/eu-west-2a", "9e1db9c4-bf0a-4583-8999-203ec002c520", "nat-foo"),
+
+				mockGetRouteTablesFromNet("vpc-foo", []osc.RouteTable{
+					{
+						RouteTableId: ptr.To("rtb-public"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-public")}},
+						Routes: &[]osc.Route{{DestinationIpRange: ptr.To("0.0.0.0/0"), GatewayId: ptr.To("igw-foo")}},
+					},
+				}),
+				mockCreateRouteTable("vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "Controlplane subnet for test-cluster-api/eu-west-2a", "rtb-kcp"),
+				mockLinkRouteTable("rtb-kcp", "subnet-kcp"),
+				mockCreateRoute("rtb-kcp", "0.0.0.0/0", "nat-foo", "nat"),
+				mockCreateRouteTable("vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "Worker subnet for test-cluster-api/eu-west-2a", "rtb-kw"),
+				mockLinkRouteTable("rtb-kw", "subnet-kw"),
+				mockCreateRoute("rtb-kw", "0.0.0.0/0", "nat-foo", "nat"),
+			},
+			clusterAsserts: []assertOSCClusterFunc{
+				assertHasClusterFinalizer(),
+				assertControlPlaneEndpoint("api.example.com", 443),
+				assertStatusClusterResources(infrastructurev1beta1.OscClusterResources{
+					Net: map[string]string{
+						"default": "vpc-foo",
+					},
+					Subnet: map[string]string{
+						"10.0.2.0/24": "subnet-public",
+						"10.0.3.0/24": "subnet-kw",
+						"10.0.4.0/24": "subnet-kcp",
+					},
+					InternetService: map[string]string{
+						"default": "igw-foo",
+					},
+					SecurityGroup: map[string]string{
+						"test-cluster-api-controlplane-9e1db9c4-bf0a-4583-8999-203ec002c520": "sg-kcp",
+						"test-cluster-api-worker-9e1db9c4-bf0a-4583-8999-203ec002c520":       "sg-kw",
+						"test-cluster-api-lb-9e1db9c4-bf0a-4583-8999-203ec002c520":           "sg-lb",
+						"test-cluster-api-node-9e1db9c4-bf0a-4583-8999-203ec002c520":         "sg-node",
+					},
+					NatService: map[string]string{
+						"eu-west-2a-9e1db9c4-bf0a-4583-8999-203ec002c520": "nat-foo",
+					},
+					PublicIPs: map[string]string{
+						"eu-west-2a-9e1db9c4-bf0a-4583-8999-203ec002c520": "ipalloc-nat-2a",
+					},
+				}),
 			},
 			next: &testcase{
 				name: "A second run has all references in cache",
@@ -1509,9 +1636,6 @@ func TestReconcileOSCCluster_Airgap(t *testing.T) {
 				mockGetRouteTablesFromNet("vpc-foo", nil),
 				mockCreateRouteTable("vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "Public subnet for test-cluster-api/eu-west-2a", "rtb-public"),
 				mockLinkRouteTable("rtb-public", "subnet-public"),
-				mockGetRouteTablesFromNet("vpc-foo", []osc.RouteTable{
-					{RouteTableId: ptr.To("rtb-public"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-public")}}},
-				}),
 				mockCreateRouteTable("vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "Controlplane subnet for test-cluster-api/eu-west-2a", "rtb-kcp"),
 				mockLinkRouteTable("rtb-kcp", "subnet-kcp"),
 				mockCreateRouteTable("vpc-foo", "9e1db9c4-bf0a-4583-8999-203ec002c520", "Worker subnet for test-cluster-api/eu-west-2a", "rtb-kw"),
@@ -1607,11 +1731,6 @@ func TestReconcileOSCCluster_Airgap(t *testing.T) {
 					},
 				}),
 
-				mockGetRouteTablesFromNet("vpc-foo", []osc.RouteTable{
-					{RouteTableId: ptr.To("rtb-public"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-public")}}},
-					{RouteTableId: ptr.To("rtb-kcp"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-kcp")}}},
-					{RouteTableId: ptr.To("rtb-kw"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-kw")}}},
-				}),
 				mockGetRouteTablesFromNet("vpc-foo", []osc.RouteTable{
 					{RouteTableId: ptr.To("rtb-public"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-public")}}},
 					{RouteTableId: ptr.To("rtb-kcp"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-kcp")}}},

--- a/controllers/osccluster_helpers_test.go
+++ b/controllers/osccluster_helpers_test.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -105,6 +106,16 @@ func patchNATIPFromPool(name string) patchOSCClusterFunc {
 func patchUseCredentials(c infrastructurev1beta1.OscCredentials) patchOSCClusterFunc {
 	return func(m *infrastructurev1beta1.OscCluster) {
 		m.Spec.Credentials = c
+	}
+}
+
+func patchDisableLB() patchOSCClusterFunc {
+	return func(m *infrastructurev1beta1.OscCluster) {
+		m.Spec.Network.Disable = append(m.Spec.Network.Disable, infrastructurev1beta1.DisableLB)
+		m.Spec.ControlPlaneEndpoint = v1beta1.APIEndpoint{
+			Host: "api.example.com",
+			Port: 443,
+		}
 	}
 }
 
@@ -530,9 +541,10 @@ func assertStatusClusterResources(rsrcs infrastructurev1beta1.OscClusterResource
 	}
 }
 
-func assertControlPlaneEndpoint(endpoint string) assertOSCClusterFunc {
+func assertControlPlaneEndpoint(endpoint string, port int32) assertOSCClusterFunc {
 	return func(t *testing.T, c *infrastructurev1beta1.OscCluster) {
 		assert.Equal(t, endpoint, c.Spec.ControlPlaneEndpoint.Host)
+		assert.Equal(t, port, c.Spec.ControlPlaneEndpoint.Port)
 	}
 }
 

--- a/controllers/osccluster_internetservice.go
+++ b/controllers/osccluster_internetservice.go
@@ -28,10 +28,6 @@ func (r *OscClusterReconciler) reconcileInternetService(ctx context.Context, clu
 		log.V(3).Info("Reusing existing internetService")
 		return reconcile.Result{}, nil
 	}
-	if clusterScope.IsInternetDisabled() {
-		log.V(3).Info("No internet service, internet is disabled")
-		return reconcile.Result{}, nil
-	}
 
 	log.V(4).Info("Reconciling internetService")
 
@@ -73,10 +69,6 @@ func (r *OscClusterReconciler) reconcileDeleteInternetService(ctx context.Contex
 	log := ctrl.LoggerFrom(ctx)
 	if clusterScope.GetNetwork().UseExisting.Net {
 		log.V(4).Info("Not deleting existing internet service")
-		return reconcile.Result{}, nil
-	}
-	if clusterScope.IsInternetDisabled() {
-		log.V(3).Info("No internet service, internet is disabled")
 		return reconcile.Result{}, nil
 	}
 	internetService, err := r.Tracker.getInternetService(ctx, clusterScope)

--- a/docs/src/topics/config-cluster.md
+++ b/docs/src/topics/config-cluster.md
@@ -356,7 +356,7 @@ Each rule is defined by:
 
 ### Automatic mode
 
-A load balancer named `loadBalancer.loadbalancername` is created.
+A load balancer named `loadBalancer.loadbalancername` is created and manages access to the Kubernetes API.
 
 ### Manual mode
 
@@ -379,6 +379,26 @@ The health check has the following attributes:
 | `healthythreshold` | `3` | false | The consecutive number of successful checks for a backend vm to be considered healthy
 | `unhealthythreshold` | `3` | false | The consecutive number of failed checks for a backend vm to be considered unhealthy
 | `timeout` | `10` | false | The timeout after which a check is considered unhealthy
+
+### Disabling
+
+The load balancer can be disabled by setting:
+
+```yaml
+spec:
+  network:
+    disable:
+    - loadbalancer
+```
+
+The control plane endpoint will then need to be configured manually:
+
+```yaml
+spec:
+  controlPlaneEndpoint:
+    host: api.example.com
+    port: 6443
+```
 
 ## Bastion
 


### PR DESCRIPTION
## Description

The Kube API load-balancer can be disabled by setting:
```yaml
spec:
  network:
    disable:
    - loadbalancer
```

The control plane endpoint will need to be configured manually:
```yaml
spec:
  controlPlaneEndpoint:
    host: api.example.com
    port: 6443
```

This allows the control plane to be handled by Kamaji.

Fixes: #558
Replaces: #559 

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context

Add any additional context or screenshots if necessary.
