### PR TITLE
feat: allow inference vm types for vm types validation

### DIFF
--- a/api/v1beta1/oscmachine_validation.go
+++ b/api/v1beta1/oscmachine_validation.go
@@ -120,7 +120,7 @@ func ValidateDeviceName(path *field.Path, deviceName string) *field.Error {
 }
 
 var isValidTinaVmType = regexp.MustCompile(`^tinav([3-9]|[1-9][0-9]).c[1-9][0-9]*r[1-9][0-9]*p[1-3]$`).MatchString
-var isValidInferenceVmType = regexp.MustCompile(`^inference7-(?:l40\.(?:medium|large)|h100\.large|h200\.4xlargeA)$`).MatchString
+var isValidInferenceVmType = regexp.MustCompile(`^inference7-(?:l40\.(?:medium|large)|h100\.(?:medium|large|xlarge|2xlarge)|h200\.(?:2xsmall|2xmedium|2xlarge|4xlarge|4xlargeA))$`).MatchString
 
 // ValidateVmType checks that vmType is a valid vmType
 func ValidateVmType(path *field.Path, vmType string) *field.Error {
@@ -132,6 +132,6 @@ func ValidateVmType(path *field.Path, vmType string) *field.Error {
 	case isValidInferenceVmType(vmType):
 		return nil
 	default:
-		return field.Invalid(path, vmType, "vmType must use either the tinavX.cXrXpX or inferenceX.gpuX.sizeX format")
+		return field.Invalid(path, vmType, "vmType must use either the tinavX.cXrXpX or inferenceX-{gpu}.{size} format")
 	}
 }

--- a/api/v1beta1/oscmachine_validation_test.go
+++ b/api/v1beta1/oscmachine_validation_test.go
@@ -69,13 +69,21 @@ func TestValidateVmType(t *testing.T) {
 		{vmType: "inference7-l40.small", valid: false},
 		{vmType: "inference7-l40.medium", valid: true},
 		{vmType: "inference7-l40.large", valid: true},
+		{vmType: "inference7-l40.xlarge", valid: false},
 
 		{vmType: "inference7-h100.small", valid: false},
-		{vmType: "inference7-h100.medium", valid: false},
+		{vmType: "inference7-h100.medium", valid: true},
 		{vmType: "inference7-h100.large", valid: true},
-		
-		{vmType: "inference7-h200.4xsmallA", valid: false},
-		{vmType: "inference7-h200.4xmediumA", valid: false},
+		{vmType: "inference7-h100.xlarge", valid: true},
+		{vmType: "inference7-h100.2xlarge", valid: true},
+
+		{vmType: "inference7-h200.small", valid: false},
+		{vmType: "inference7-h200.medium", valid: false},
+		{vmType: "inference7-h200.large", valid: false},
+		{vmType: "inference7-h200.2xsmall", valid: true},
+		{vmType: "inference7-h200.2xmedium", valid: true},
+		{vmType: "inference7-h200.2xlarge", valid: true},
+		{vmType: "inference7-h200.4xlarge", valid: true},
 		{vmType: "inference7-h200.4xlargeA", valid: true},
 	}
 	for _, tc := range tcs {


### PR DESCRIPTION
# 📦 Pull Request Template

## Description

Modification of the validate vm type function. This change allows inference/gpu types to be set for the oscmachines.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [x] Unit tests
- [x] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [ ] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [ ] My commits include appropriate [Gitmoji](https://gitmoji.dev/)
