### PR TITLE
👷 ci: trigger E2E tests on deps upgrade

### DIFF
--- a/.github/workflows/unit-quickstart-e2e-test.yaml
+++ b/.github/workflows/unit-quickstart-e2e-test.yaml
@@ -10,6 +10,7 @@ on:
       - ".github/workflows/unit-quickstart-e2e-test.yaml"
       - "github_actions/deploy_cluster/**"
       - "**.go"
+      - "go.*"
       - "**.yaml"
       - "!capm.yaml"
       - "!osc-secret.yaml"


### PR DESCRIPTION
## Description

E2E tests were not triggered by go.mod updates.

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [x] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [x] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
