### PR TITLE
✨ feat(OscMachine): handle tag keys having already the tags prefix

### DIFF
--- a/cloud/utils/utils.go
+++ b/cloud/utils/utils.go
@@ -21,6 +21,7 @@ func ConvertsTagsToUserDataOutscaleSection(tags map[string]string) string {
 	_, _ = fmt.Fprintln(b, "-----BEGIN OUTSCALE SECTION-----")
 	_, _ = fmt.Fprintln(b, "filter_private_section=true")
 	for key, value := range tags {
+		key = strings.TrimPrefix(key, "tags.")
 		_, _ = fmt.Fprintf(b, "tags.%s=%s\n", key, value)
 	}
 	_, _ = fmt.Fprintln(b, "-----END OUTSCALE SECTION-----")

--- a/cloud/utils/utils_test.go
+++ b/cloud/utils/utils_test.go
@@ -12,12 +12,25 @@ import (
 )
 
 func TestConvertsTagsToUserDataOutscaleSection(t *testing.T) {
-	assert.Equal(t, "", ConvertsTagsToUserDataOutscaleSection(map[string]string{}))
+	t.Run("Empty tags generate an empty user data section", func(t *testing.T) {
+		assert.Equal(t, "", ConvertsTagsToUserDataOutscaleSection(map[string]string{}))
+	})
 
-	expected := `-----BEGIN OUTSCALE SECTION-----
+	t.Run("Generating a user data section with tags", func(t *testing.T) {
+		expected := `-----BEGIN OUTSCALE SECTION-----
 filter_private_section=true
 tags.key1=value1
 -----END OUTSCALE SECTION-----
 `
-	assert.Equal(t, expected, ConvertsTagsToUserDataOutscaleSection(map[string]string{"key1": "value1"}))
+		assert.Equal(t, expected, ConvertsTagsToUserDataOutscaleSection(map[string]string{"key1": "value1"}))
+	})
+
+	t.Run("tags. prefixes are trimmed", func(t *testing.T) {
+		expected := `-----BEGIN OUTSCALE SECTION-----
+filter_private_section=true
+tags.key1=value1
+-----END OUTSCALE SECTION-----
+`
+		assert.Equal(t, expected, ConvertsTagsToUserDataOutscaleSection(map[string]string{"tags.key1": "value1"}))
+	})
 }


### PR DESCRIPTION
## Description

In the Outscale User Data section, setting a tag can be done by adding:
```
tags.key=value
```

Based on this, one might be tempted to set tags by (incorrectly) configuring an OscMachine with:
```yaml
tags:
  tags.key: value
```
instead of the valid:
```yaml
tags:
  key: value
```

This PR removes any `tags.` prefix found in tag keys to always generate a valid User Data section.

Refs: #723 

## Type of Change

Please check the relevant option(s):

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
