### PR TITLE
🐛 fix(OscCluster/OscMachine): abort reconciliation if owner Cluster/Machine has been deleted

### DIFF
--- a/controllers/osccluster_controller_test.go
+++ b/controllers/osccluster_controller_test.go
@@ -35,12 +35,6 @@ import (
 
 func runClusterTest(t *testing.T, tc testcase) {
 	c, oc := loadClusterSpecs(t, tc.clusterSpec, tc.clusterBaseSpec)
-	oc.Labels = map[string]string{clusterv1.ClusterNameLabel: oc.Name}
-	oc.OwnerReferences = []metav1.OwnerReference{{
-		APIVersion: "cluster.x-k8s.io/v1beta1",
-		Kind:       "Cluster",
-		Name:       c.Name,
-	}}
 	for _, fn := range tc.clusterPatches {
 		fn(oc)
 	}
@@ -2817,6 +2811,14 @@ func TestReconcileOSCCluster_Delete(t *testing.T) {
 				mockDeleteLoadBalancer("test-cluster-api-k8s"),
 			},
 			assertDeleted: true,
+		},
+		{
+			name:            "trying to delete a cluster without owner",
+			clusterSpec:     "ready-1.0",
+			clusterBaseSpec: "-",
+			clusterPatches: []patchOSCClusterFunc{
+				patchDeleteCluster(),
+			},
 		},
 	}
 	for _, tc := range tcs {


### PR DESCRIPTION
## Description

When a Machine/Cluster is hard deleted, CAPOSC is unable to delete the OscMachine/OscCluster, and loops with an error.

It is impossible to allow CAPOSC to delete the OscMachine/OscCluster in the current architecture, so the PR aborts reconciliation.

The cloud resources will need to be removed manually.

Fixes: #497

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
