### PR TITLE
🐛 fix(OscMachine/validation/webhook): loadbalancer disabling fixes

### DIFF
--- a/api/v1beta1/osccluster_webhook.go
+++ b/api/v1beta1/osccluster_webhook.go
@@ -9,6 +9,7 @@ package v1beta1
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -61,18 +62,19 @@ func (OscClusterWebhook) ValidateUpdate(_ context.Context, obj runtime.Object, o
 	}
 	var allErrs field.ErrorList
 	old := oldRaw.(*OscCluster)
-
-	if r.Spec.Network.LoadBalancer.LoadBalancerName != old.Spec.Network.LoadBalancer.LoadBalancerName {
-		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("network", "loadBalancer", "loadbalancername"),
-				r.Spec.Network.LoadBalancer.LoadBalancerName, "field is immutable"),
-		)
-	}
-	if r.Spec.Network.LoadBalancer.LoadBalancerType != old.Spec.Network.LoadBalancer.LoadBalancerType {
-		allErrs = append(allErrs,
-			field.Invalid(field.NewPath("network", "loadBalancer", "loadbalancertype"),
-				r.Spec.Network.LoadBalancer.LoadBalancerType, "field is immutable"),
-		)
+	if !slices.Contains(r.Spec.Network.Disable, DisableLB) {
+		if r.Spec.Network.LoadBalancer.LoadBalancerName != old.Spec.Network.LoadBalancer.LoadBalancerName {
+			allErrs = append(allErrs,
+				field.Invalid(field.NewPath("network", "loadBalancer", "loadbalancername"),
+					r.Spec.Network.LoadBalancer.LoadBalancerName, "field is immutable"),
+			)
+		}
+		if r.Spec.Network.LoadBalancer.LoadBalancerType != old.Spec.Network.LoadBalancer.LoadBalancerType {
+			allErrs = append(allErrs,
+				field.Invalid(field.NewPath("network", "loadBalancer", "loadbalancertype"),
+					r.Spec.Network.LoadBalancer.LoadBalancerType, "field is immutable"),
+			)
+		}
 	}
 	if len(allErrs) == 0 {
 		return nil, nil

--- a/api/v1beta1/osccluster_webhook_test.go
+++ b/api/v1beta1/osccluster_webhook_test.go
@@ -23,6 +23,30 @@ func TestOscCluster_ValidateCreate(t *testing.T) {
 		expValidateCreateErr error
 	}{
 		{
+			name: "disabled and empty loadBalancer",
+			clusterSpec: infrastructurev1beta1.OscClusterSpec{
+				Network: infrastructurev1beta1.OscNetwork{
+					Disable: []infrastructurev1beta1.OscDisable{
+						infrastructurev1beta1.DisableLB,
+					},
+				},
+			},
+		},
+		{
+			name: "disabled and non empty loadBalancer",
+			clusterSpec: infrastructurev1beta1.OscClusterSpec{
+				Network: infrastructurev1beta1.OscNetwork{
+					Disable: []infrastructurev1beta1.OscDisable{
+						infrastructurev1beta1.DisableLB,
+					},
+					LoadBalancer: infrastructurev1beta1.OscLoadBalancer{
+						LoadBalancerName: "test-webhook@test",
+					},
+				},
+			},
+			expValidateCreateErr: errors.New("OscCluster.infrastructure.cluster.x-k8s.io \"webhook-test\" is invalid: network.loadBalancer: Forbidden: loadBalancer must be empty when disabled"),
+		},
+		{
 			name: "bad loadBalancerName",
 			clusterSpec: infrastructurev1beta1.OscClusterSpec{
 				Network: infrastructurev1beta1.OscNetwork{

--- a/controllers/osccluster_helpers_test.go
+++ b/controllers/osccluster_helpers_test.go
@@ -112,6 +112,7 @@ func patchUseCredentials(c infrastructurev1beta1.OscCredentials) patchOSCCluster
 func patchDisableLB() patchOSCClusterFunc {
 	return func(m *infrastructurev1beta1.OscCluster) {
 		m.Spec.Network.Disable = append(m.Spec.Network.Disable, infrastructurev1beta1.DisableLB)
+		m.Spec.Network.LoadBalancer = infrastructurev1beta1.OscLoadBalancer{}
 		m.Spec.ControlPlaneEndpoint = v1beta1.APIEndpoint{
 			Host: "api.example.com",
 			Port: 443,

--- a/controllers/oscmachine_vm.go
+++ b/controllers/oscmachine_vm.go
@@ -145,7 +145,7 @@ func (r *OscMachineReconciler) reconcileVm(ctx context.Context, clusterScope *sc
 
 	machineScope.SetReady()
 
-	if vmSpec.GetRole() == infrastructurev1beta1.RoleControlPlane {
+	if vmSpec.GetRole() == infrastructurev1beta1.RoleControlPlane && !clusterScope.IsLBDisabled() {
 		svc := r.Cloud.LoadBalancer(clusterScope.Tenant)
 		loadBalancerName := clusterScope.GetLoadBalancer().LoadBalancerName
 		loadbalancer, err := svc.GetLoadBalancer(ctx, loadBalancerName)
@@ -220,7 +220,7 @@ func (r *OscMachineReconciler) reconcileDeleteVm(ctx context.Context, clusterSco
 	}
 
 	vmSpec := machineScope.GetVm()
-	if vmSpec.GetRole() == infrastructurev1beta1.RoleControlPlane {
+	if vmSpec.GetRole() == infrastructurev1beta1.RoleControlPlane && !clusterScope.IsLBDisabled() {
 		svc := r.Cloud.LoadBalancer(clusterScope.Tenant)
 		loadBalancerName := clusterScope.GetLoadBalancer().LoadBalancerName
 		loadbalancer, err := svc.GetLoadBalancer(ctx, loadBalancerName)


### PR DESCRIPTION
## Description

- validate assertion against empty loadbalancer when disabled
- prevent validation of osc loadbalancer attributes when disabled
- prevent setdefault values in osc loadbalancer while reconciling oscmachine vms
- prevent osc loadbalancer webhook validation in update webhook when disabled

Primary author: @ddavid-numspot 

Refs: #740

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
