### PR TITLE
🐛 fix: controller is stuck when a resource has been deleted

### DIFF
--- a/controllers/osccluster_bastion.go
+++ b/controllers/osccluster_bastion.go
@@ -119,7 +119,7 @@ func (r *OscClusterReconciler) reconcileBastion(ctx context.Context, clusterScop
 
 	vm, err := r.Tracker.getBastion(ctx, clusterScope)
 	switch {
-	case errors.Is(err, ErrNoResourceFound):
+	case IsNotFound(err):
 	case err != nil:
 		return reconcile.Result{}, fmt.Errorf("get existing: %w", err)
 	default:

--- a/controllers/osccluster_controller_test.go
+++ b/controllers/osccluster_controller_test.go
@@ -2603,6 +2603,106 @@ func TestReconcileOSCCluster_Update(t *testing.T) {
 				}),
 			},
 		},
+		{
+			name:            "A NAT service has been deleted, it is recreated with the associated routes",
+			clusterSpec:     "ready-1.0",
+			clusterBaseSpec: "base",
+			clusterPatches: []patchOSCClusterFunc{
+				patchIncrementGeneration(),
+			},
+			mockFuncs: []mockFunc{
+				mockNetFound("vpc-foo"),
+				mockSubnetFound("subnet-public"),
+				mockSubnetFound("subnet-kw"),
+				mockSubnetFound("subnet-kcp"),
+				mockInternetServiceFound("vpc-foo", "igw-foo"),
+
+				mockGetSecurityGroup("sg-kw", &osc.SecurityGroup{
+					SecurityGroupId: ptr.To("sg-kw"),
+					InboundRules: &[]osc.SecurityGroupRule{
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](10250), ToPortRange: ptr.To[int32](10250), IpRanges: &[]string{"10.0.3.0/24"}},
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](10250), ToPortRange: ptr.To[int32](10250), IpRanges: &[]string{"10.0.4.0/24"}},
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](443), ToPortRange: ptr.To[int32](443), IpRanges: &[]string{"10.0.4.0/24"}},
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](1024), ToPortRange: ptr.To[int32](65535), IpRanges: &[]string{"10.0.4.0/24"}},
+					},
+				}),
+				mockGetSecurityGroup("sg-kcp", &osc.SecurityGroup{
+					SecurityGroupId: ptr.To("sg-kcp"),
+					InboundRules: &[]osc.SecurityGroupRule{
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](10250), ToPortRange: ptr.To[int32](10252), IpRanges: &[]string{"10.0.4.0/24"}},
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](6443), ToPortRange: ptr.To[int32](6443), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](2378), ToPortRange: ptr.To[int32](2380), IpRanges: &[]string{"10.0.4.0/24"}},
+					},
+				}),
+				mockGetSecurityGroup("sg-lb", &osc.SecurityGroup{
+					SecurityGroupId: ptr.To("sg-lb"),
+					InboundRules: &[]osc.SecurityGroupRule{
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](6443), ToPortRange: ptr.To[int32](6443), IpRanges: &[]string{"0.0.0.0/0"}},
+					},
+					OutboundRules: &[]osc.SecurityGroupRule{
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](6443), ToPortRange: ptr.To[int32](6443), IpRanges: &[]string{"10.0.4.0/24"}},
+					},
+				}),
+				mockGetSecurityGroup("sg-node", &osc.SecurityGroup{
+					SecurityGroupId: ptr.To("sg-node"),
+					InboundRules: &[]osc.SecurityGroupRule{
+						{IpProtocol: ptr.To("icmp"), FromPortRange: ptr.To[int32](8), ToPortRange: ptr.To[int32](8), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](179), ToPortRange: ptr.To[int32](179), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("udp"), FromPortRange: ptr.To[int32](4789), ToPortRange: ptr.To[int32](4789), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("udp"), FromPortRange: ptr.To[int32](5473), ToPortRange: ptr.To[int32](5473), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("udp"), FromPortRange: ptr.To[int32](51820), ToPortRange: ptr.To[int32](51821), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("4"), FromPortRange: ptr.To[int32](-1), ToPortRange: ptr.To[int32](-1), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("udp"), FromPortRange: ptr.To[int32](8285), ToPortRange: ptr.To[int32](8285), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("udp"), FromPortRange: ptr.To[int32](8472), ToPortRange: ptr.To[int32](8472), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](4240), ToPortRange: ptr.To[int32](4240), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](4244), ToPortRange: ptr.To[int32](4244), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("udp"), FromPortRange: ptr.To[int32](51871), ToPortRange: ptr.To[int32](51871), IpRanges: &[]string{"10.0.0.0/16"}},
+						{IpProtocol: ptr.To("tcp"), FromPortRange: ptr.To[int32](30000), ToPortRange: ptr.To[int32](32767), IpRanges: &[]string{"10.0.0.0/16"}},
+					},
+					OutboundRules: &[]osc.SecurityGroupRule{
+						{IpProtocol: ptr.To("-1"), FromPortRange: ptr.To[int32](-1), ToPortRange: ptr.To[int32](-1), IpRanges: &[]string{"0.0.0.0/0"}},
+						{IpProtocol: ptr.To("-1"), FromPortRange: ptr.To[int32](-1), ToPortRange: ptr.To[int32](-1), IpRanges: &[]string{"10.0.0.0/16"}},
+					},
+				}),
+
+				mockGetRouteTablesFromNet("vpc-foo", []osc.RouteTable{
+					{
+						RouteTableId: ptr.To("rtb-public"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-public")}},
+						Routes: &[]osc.Route{{DestinationIpRange: ptr.To("0.0.0.0/0"), GatewayId: ptr.To("igw-foo")}},
+					},
+					{
+						RouteTableId: ptr.To("rtb-kcp"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-kcp")}},
+						Routes: &[]osc.Route{{DestinationIpRange: ptr.To("0.0.0.0/0"), GatewayId: ptr.To("nat-foo")}},
+					},
+					{
+						RouteTableId: ptr.To("rtb-kw"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-kw")}},
+						Routes: &[]osc.Route{{DestinationIpRange: ptr.To("0.0.0.0/0"), GatewayId: ptr.To("nat-foo")}},
+					},
+				}),
+				mockNatServiceNotFound("nat-foo"),
+				mockPublicIpFound("ipalloc-nat", &osc.PublicIp{PublicIp: ptr.To("1.2.3.4")}),
+				mockCreateNatService("ipalloc-nat", "subnet-public", "eu-west-2a-9e1db9c4-bf0a-4583-8999-203ec002c520", "Nat service for test-cluster-api/eu-west-2a", "9e1db9c4-bf0a-4583-8999-203ec002c520", "nat-bar"),
+
+				mockGetRouteTablesFromNet("vpc-foo", []osc.RouteTable{
+					{
+						RouteTableId: ptr.To("rtb-public"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-public")}},
+						Routes: &[]osc.Route{{DestinationIpRange: ptr.To("0.0.0.0/0"), GatewayId: ptr.To("igw-foo")}},
+					},
+					{
+						RouteTableId: ptr.To("rtb-kcp"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-kcp")}},
+						Routes: &[]osc.Route{},
+					},
+					{
+						RouteTableId: ptr.To("rtb-kw"), LinkRouteTables: &[]osc.LinkRouteTable{{SubnetId: ptr.To("subnet-kw")}},
+						Routes: &[]osc.Route{},
+					},
+				}),
+				mockCreateRoute("rtb-kcp", "0.0.0.0/0", "nat-bar", "nat"),
+				mockCreateRoute("rtb-kw", "0.0.0.0/0", "nat-bar", "nat"),
+
+				mockLoadBalancerFound("test-cluster-api-k8s", "test-cluster-api-k8s-9e1db9c4-bf0a-4583-8999-203ec002c520"),
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {

--- a/controllers/osccluster_helpers_test.go
+++ b/controllers/osccluster_helpers_test.go
@@ -369,6 +369,14 @@ func mockGetNatServiceFromClientToken(token string, ns *osc.NatService) mockFunc
 	}
 }
 
+func mockNatServiceNotFound(id string) mockFunc {
+	return func(s *MockCloudServices) {
+		s.NatServiceMock.EXPECT().
+			GetNatService(gomock.Any(), gomock.Eq(id)).
+			Return(nil, nil)
+	}
+}
+
 func mockNatServiceFound(id string) mockFunc {
 	return func(s *MockCloudServices) {
 		s.NatServiceMock.EXPECT().

--- a/controllers/osccluster_internetservice.go
+++ b/controllers/osccluster_internetservice.go
@@ -7,7 +7,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
@@ -33,7 +32,7 @@ func (r *OscClusterReconciler) reconcileInternetService(ctx context.Context, clu
 
 	internetService, err := r.Tracker.getInternetService(ctx, clusterScope)
 	switch {
-	case errors.Is(err, ErrNoResourceFound):
+	case IsNotFound(err):
 	case err != nil:
 		return reconcile.Result{}, fmt.Errorf("get existing: %w", err)
 	case internetService.NetId != nil:

--- a/controllers/osccluster_natservice.go
+++ b/controllers/osccluster_natservice.go
@@ -7,7 +7,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
@@ -39,7 +38,7 @@ func (r *OscClusterReconciler) reconcileNatService(ctx context.Context, clusterS
 	for _, natServiceSpec := range natServiceSpecs {
 		natService, err := r.Tracker.getNatService(ctx, natServiceSpec, clusterScope)
 		switch {
-		case errors.Is(err, ErrNoResourceFound):
+		case IsNotFound(err):
 		case err != nil:
 			return reconcile.Result{}, fmt.Errorf("find existing: %w", err)
 		default:

--- a/controllers/osccluster_net.go
+++ b/controllers/osccluster_net.go
@@ -7,7 +7,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
@@ -28,7 +27,7 @@ func (r *OscClusterReconciler) reconcileNet(ctx context.Context, clusterScope *s
 
 	net, err := r.Tracker.getNet(ctx, clusterScope)
 	switch {
-	case errors.Is(err, ErrNoResourceFound):
+	case IsNotFound(err) && !clusterScope.GetNetwork().UseExisting.Net:
 	case err != nil:
 		return reconcile.Result{}, fmt.Errorf("find existing: %w", err)
 	default:

--- a/controllers/osccluster_netaccesspoint.go
+++ b/controllers/osccluster_netaccesspoint.go
@@ -7,7 +7,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
@@ -62,7 +61,7 @@ func (r *OscClusterReconciler) reconcileNetAccessPoints(ctx context.Context, clu
 	for _, service := range clusterScope.GetNetwork().NetAccessPoints {
 		netAccessPoint, err := r.Tracker.getNetAccessPoint(ctx, service, clusterScope)
 		switch {
-		case errors.Is(err, ErrNoResourceFound):
+		case IsNotFound(err):
 		case err != nil:
 			return reconcile.Result{}, fmt.Errorf("get existing: %w", err)
 		default:

--- a/controllers/osccluster_netpeering.go
+++ b/controllers/osccluster_netpeering.go
@@ -7,7 +7,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
@@ -47,7 +46,7 @@ func (r *OscClusterReconciler) reconcileNetPeering(ctx context.Context, clusterS
 	svc := r.Cloud.NetPeering(clusterScope.Tenant)
 	np, err := r.Tracker.getNetPeering(ctx, clusterScope)
 	switch {
-	case errors.Is(err, ErrNoResourceFound):
+	case IsNotFound(err):
 	case err != nil:
 		return reconcile.Result{}, fmt.Errorf("get existing: %w", err)
 	case np.State.GetName() == "active":

--- a/controllers/osccluster_resources.go
+++ b/controllers/osccluster_resources.go
@@ -436,6 +436,7 @@ func (t *ClusterResourceTracker) setBastionId(clusterScope *scope.ClusterScope, 
 	}
 	rsrc.Bastion[defaultResource] = id
 }
+
 func (t *ClusterResourceTracker) _getSecurityGroupOrId(ctx context.Context, sg infrastructurev1beta1.OscSecurityGroup, clusterScope *scope.ClusterScope) (*osc.SecurityGroup, string, error) {
 	if sg.ResourceId != "" {
 		return nil, sg.ResourceId, nil

--- a/controllers/osccluster_securitygroup.go
+++ b/controllers/osccluster_securitygroup.go
@@ -7,7 +7,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -61,7 +60,7 @@ func (r *OscClusterReconciler) reconcileSecurityGroupAddRules(ctx context.Contex
 // reconcileSecurityGroupDeleteRules deletes all rules not in spec for a securityGroup.
 func (r *OscClusterReconciler) reconcileSecurityGroupDeleteRules(ctx context.Context, clusterScope *scope.ClusterScope, securityGroupRulesSpec []infrastructurev1beta1.OscSecurityGroupRule, sg *osc.SecurityGroup) (reconcile.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
-	var checkRules = func(flow string, rules []osc.SecurityGroupRule) error {
+	checkRules := func(flow string, rules []osc.SecurityGroupRule) error {
 		for _, rule := range rules {
 			// Skipping rule created by CCM. There is no way to be sure this comes from the CCM,
 			// but the CCM creates rules with an associated SG, and the config from the CRD only uses ipRanges.
@@ -126,7 +125,7 @@ func (r *OscClusterReconciler) reconcileSecurityGroup(ctx context.Context, clust
 	for _, securityGroupSpec := range securityGroupsSpec {
 		securityGroup, err := r.Tracker.getSecurityGroup(ctx, securityGroupSpec, clusterScope)
 		switch {
-		case errors.Is(err, ErrNoResourceFound):
+		case IsNotFound(err):
 			log.V(3).Info("Creating securityGroup", "securityGroupName", securityGroupSpec.Name)
 			name := clusterScope.GetSecurityGroupName(securityGroupSpec)
 			securityGroup, err = securityGroupSvc.CreateSecurityGroup(ctx, netId, clusterScope.GetUID(), name, securityGroupSpec.Description, securityGroupSpec.Tag, securityGroupSpec.Roles)

--- a/controllers/osccluster_subnet.go
+++ b/controllers/osccluster_subnet.go
@@ -7,7 +7,6 @@ package controllers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	infrastructurev1beta1 "github.com/outscale/cluster-api-provider-outscale/api/v1beta1"
@@ -35,7 +34,7 @@ func (r *OscClusterReconciler) reconcileSubnets(ctx context.Context, clusterScop
 	for _, subnetSpec := range clusterScope.GetSubnets() {
 		subnet, err := r.Tracker.getSubnet(ctx, subnetSpec, clusterScope)
 		switch {
-		case errors.Is(err, ErrNoResourceFound):
+		case IsNotFound(err) && !clusterScope.GetNetwork().UseExisting.Net:
 		case err != nil:
 			return reconcile.Result{}, fmt.Errorf("get existing: %w", err)
 		default:

--- a/controllers/oscmachine_vm.go
+++ b/controllers/oscmachine_vm.go
@@ -44,7 +44,7 @@ func (r *OscMachineReconciler) reconcileVm(ctx context.Context, clusterScope *sc
 	switch {
 	case err == nil:
 		machineScope.SetVmState(infrastructurev1beta1.VmState(vm.GetState()))
-	case !errors.Is(err, ErrNoResourceFound):
+	case !IsNotFound(err):
 		return reconcile.Result{}, fmt.Errorf("cannot get VM: %w", err)
 	default:
 		// Check if a machine needs to be placed in a subregion.


### PR DESCRIPTION
## Description

Reconcilers now properly recreate disappeared resources (i.e. resources deleted by someone/something outside CAPOSC).

Fixes: #818

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [ ] Manual testing
- [x] Unit tests
- [ ] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
