### PR TITLE
🐛 fix: crash in ClusterResourceTracker.getNetId

### DIFF
--- a/cloud/services/cloud.go
+++ b/cloud/services/cloud.go
@@ -24,7 +24,7 @@ type Servicer interface {
 }
 
 type Services struct {
-	once          sync.Once
+	mu            sync.Mutex
 	defaultTenant tenant.Tenant
 }
 
@@ -33,14 +33,16 @@ func NewServices() (*Services, error) {
 }
 
 func (s *Services) DefaultTenant() (tenant.Tenant, error) {
-	var err error
-	s.once.Do(func() {
-		s.defaultTenant, err = tenant.TenantFromEnv()
-	})
-	if err != nil {
-		return nil, fmt.Errorf("tenant from env: %w", err)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.defaultTenant == nil {
+		var err error
+		s.defaultTenant, err = tenant.Default()
+		if err != nil {
+			return nil, fmt.Errorf("default tenant: %w", err)
+		}
 	}
-	return s.defaultTenant, err
+	return s.defaultTenant, nil
 }
 
 // Net returns the Net service

--- a/cloud/tenant/default.go
+++ b/cloud/tenant/default.go
@@ -11,10 +11,10 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/profile"
 )
 
-func TenantFromEnv() (Tenant, error) {
-	prof, err := profile.New(profile.FromEnv())
+func Default() (Tenant, error) {
+	prof, err := profile.New()
 	if err != nil {
 		return nil, fmt.Errorf("tenant from env: %w", err)
 	}
-	return TenantFromProfile(prof)
+	return FromProfile(prof)
 }

--- a/cloud/tenant/file.go
+++ b/cloud/tenant/file.go
@@ -11,7 +11,7 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/profile"
 )
 
-func TenantFromFile(path, profileName string) (Tenant, error) {
+func FromFile(path, profileName string) (Tenant, error) {
 	if profileName == "" {
 		profileName = "default"
 	}
@@ -19,5 +19,5 @@ func TenantFromFile(path, profileName string) (Tenant, error) {
 	if err != nil {
 		return nil, fmt.Errorf("from file: %w", err)
 	}
-	return TenantFromProfile(prof)
+	return FromProfile(prof)
 }

--- a/cloud/tenant/tenant.go
+++ b/cloud/tenant/tenant.go
@@ -39,7 +39,7 @@ func (t *tenant) Client() *osc.Client {
 	return t.client
 }
 
-func TenantFromProfile(prof *profile.Profile) (Tenant, error) {
+func FromProfile(prof *profile.Profile) (Tenant, error) {
 	c, err := newSDKClient(prof)
 	if err != nil {
 		return nil, err

--- a/controllers/tenant.go
+++ b/controllers/tenant.go
@@ -15,27 +15,36 @@ import (
 	"github.com/outscale/osc-sdk-go/v3/pkg/profile"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func getTenant(ctx context.Context, cl client.Client, c services.Servicer, cluster *infrastructurev1beta1.OscCluster) (tenant.Tenant, error) {
+	logger := log.FromContext(ctx).V(4)
 	switch {
 	case cluster.Spec.Credentials.FromFile != "":
-		return tenant.TenantFromFile(cluster.Spec.Credentials.FromFile, cluster.Spec.Credentials.Profile)
+		logger.Info("Using tenant from file", "file", cluster.Spec.Credentials.FromFile, "profile", cluster.Spec.Credentials.Profile)
+		return tenant.FromFile(cluster.Spec.Credentials.FromFile, cluster.Spec.Credentials.Profile)
 	case cluster.Spec.Credentials.FromSecret != "":
+		logger.Info("Using tenant from secret", "secret", cluster.Spec.Credentials.FromSecret)
 		return getTenantFromSecret(ctx, cl, cluster.Spec.Credentials.FromSecret, cluster.Namespace)
 	default:
+		logger.Info("Using default tenant")
 		return c.DefaultTenant()
 	}
 }
 
 func getMgmtTenant(ctx context.Context, cl client.Client, c services.Servicer, cluster *infrastructurev1beta1.OscCluster) (tenant.Tenant, error) {
+	logger := log.FromContext(ctx).V(4)
 	creds := cluster.Spec.Network.NetPeering.ManagementCredentials
 	switch {
 	case creds.FromFile != "":
-		return tenant.TenantFromFile(creds.FromFile, creds.Profile)
+		logger.Info("Using tenant from file for management cluster", "file", creds.FromFile, "profile", creds.Profile)
+		return tenant.FromFile(creds.FromFile, creds.Profile)
 	case creds.FromSecret != "":
+		logger.Info("Using tenant from secret for management cluster", "secret", creds.FromSecret)
 		return getTenantFromSecret(ctx, cl, creds.FromSecret, cluster.Namespace)
 	default:
+		logger.Info("Using default tenant for management cluster")
 		return c.DefaultTenant()
 	}
 }
@@ -49,7 +58,7 @@ func getTenantFromSecret(ctx context.Context, cl client.Client, name, ns string)
 	if err != nil {
 		return nil, fmt.Errorf("tenant from secret: %w", err)
 	}
-	return tenant.TenantFromProfile(&profile.Profile{
+	return tenant.FromProfile(&profile.Profile{
 		AccessKey: string(secret.Data["access_key"]),
 		SecretKey: string(secret.Data["secret_key"]),
 		Region:    string(secret.Data["region"]),


### PR DESCRIPTION
## Description

When credentials are invalid, a nil pointer exception may be generated.

## Type of Change

Please check the relevant option(s):

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Code cleanup or refactor
- [ ] 📝 Documentation update
- [ ] 🔧 Build or CI-related change
- [ ] 🔒 Security fix
- [ ] Other (specify):

## How Has This Been Tested?

Please describe the test strategy:

- [x] Manual testing
- [ ] Unit tests
- [x] Integration tests
- [ ] Not tested yet

## Checklist

* [x] I have followed the [Contributing Guidelines](../blob/main/CONTRIBUTING.md)
* [x] I have added tests or explained why they are not needed
* [x] I have updated relevant documentation (README, examples, etc.)
* [x] My changes follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
* [x] My commits include appropriate [Gitmoji](https://gitmoji.dev/)

## Additional Context
